### PR TITLE
create body of email using last change log entry

### DIFF
--- a/lib/Dist/Zilla/Plugin/EmailNotify.pm
+++ b/lib/Dist/Zilla/Plugin/EmailNotify.pm
@@ -6,7 +6,7 @@ package Dist::Zilla::Plugin::EmailNotify;
 use Moose;
 with 'Dist::Zilla::Role::AfterRelease';
 
-use Email::Stuff;
+use Email::Stuffer;
 use IO::File;
 
 use namespace::autoclean;
@@ -91,10 +91,11 @@ $authors
 
     $self->log($text_body);
 
-    my $email = Email::Stuff->subject("$name $v released!")
-                            ->from($from)
-                            ->to($to)
-                            ->text_body($text_body);
+    my $email
+	  = Email::Stuffer->subject("$name $v released!")
+	  ->from($from)
+	  ->to($to)
+	  ->text_body($text_body);
 
     $cc  and $email->cc($cc);
     $bcc and $email->bcc($bcc);


### PR DESCRIPTION
Hello

I've improved your EmailNotify plugin to send mail with more interesting content for the users: the email will contain the change log of the release. 

See this example of a mail generated with this version of EmailNotify: 
http://sourceforge.net/mailarchive/message.php?msg_id=31407841

I'll package this plugin for Debian once the new version hits CPAN.

All the best
