### PR TITLE
Remove the use of two installers

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -13,7 +13,6 @@ version = 0.003
 [Test::Compile]
 
 [AutoPrereqs]
-[ModuleBuild]
 [PodWeaver]
 [ReadmeFromPod]
 [CheckChangeLog]


### PR DESCRIPTION
[MakeMaker] is used via [@Basic], and is totally sufficient. [ModuleBuild] should be avoided whenever possible.
