### PR TITLE
- Adding provided modules to meta using dzil plugin [MetaProvides::Package].

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -26,6 +26,11 @@ namespace::autoclean = 0
 [CheckChangeLog]
 [PkgVersion]
 
+[MetaProvides::Package]
+inherit_version = 0
+inherit_missing = 0
+meta_noindex = 1
+
 [MetaJSON]
 [MetaResources]
 bugtracker.web  = https://github.com/xsawyerx/dist-zilla-plugin-emailnotify.git


### PR DESCRIPTION
Hi Sawyer, please review the above change.

Many Thanks.
Best Regards,
Mohammad S Anwar
